### PR TITLE
fix: get default subnet when using custom vpcID

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	"github.com/loft-sh/devpod-provider-aws/pkg/aws"
-	"github.com/pkg/errors"
-
 	"github.com/loft-sh/devpod/pkg/log"
 	"github.com/loft-sh/devpod/pkg/provider"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +44,11 @@ func (cmd *DeleteCmd) Run(
 	machine *provider.Machine,
 	logs log.Logger,
 ) error {
-	instances, err := aws.GetDevpodInstance(ctx, providerAws.AwsConfig, providerAws.Config.MachineID)
+	instances, err := aws.GetDevpodInstance(
+		ctx,
+		providerAws.AwsConfig,
+		providerAws.Config.MachineID,
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/loft-sh/devpod-provider-aws/pkg/aws"
-
 	"github.com/loft-sh/devpod/pkg/log"
 	"github.com/loft-sh/devpod/pkg/provider"
 	"github.com/spf13/cobra"

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	"github.com/loft-sh/devpod-provider-aws/pkg/aws"
-	"github.com/pkg/errors"
-
 	"github.com/loft-sh/devpod/pkg/log"
 	"github.com/loft-sh/devpod/pkg/provider"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
This PR fixes a situation where specifying a custom VPC ID, would not find a default subnet in the same VPC

If no default subnet is found, it will search for the subnet with most free IPs inside the specified VPC and with ability to assign public IP addresses

If nothing is found, an error is returned, requesting to manually specify the subnet

Fix #18 
Resolves ENG-1790