### PR TITLE
Add AWS_ROOT_DEVICE for systems that do not use /dev/sda1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This provider has the following options
 |-------------------|----------|---------------------------------------|-------------------------|
 | AWS_AMI           | false    | The disk image to use.                | latest ubuntu in the region with proper architecture for the instance  |
 | AWS_DISK_SIZE     | false    | The disk size to use.                 | 40                      |
-| AWS_ROOT_DEVICE   | false    | The ID of the root device.            | whatever is defined in the AMI  |
+| AWS_ROOT_DEVICE   | false    | The ID of the root device.            | The `RootDeviceName` property of the AMI, or `/dev/sda1` if undefined  |
 | AWS_INSTANCE_TYPE | false    | The machine type to use.              | c5.xlarge               |
 | AWS_REGION        | true     | The aws cloud region to create the VM |                         |
 | AWS_VPC_ID        | false    | The vpc id to use.                    |                         |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This provider has the following options
 |-------------------|----------|---------------------------------------|-------------------------|
 | AWS_AMI           | false    | The disk image to use.                | latest ubuntu in the region with proper architecture for the instance  |
 | AWS_DISK_SIZE     | false    | The disk size to use.                 | 40                      |
+| AWS_ROOT_DEVICE   | false    | The ID of the root device.            | whatever is defined in the AMI  |
 | AWS_INSTANCE_TYPE | false    | The machine type to use.              | c5.xlarge               |
 | AWS_REGION        | true     | The aws cloud region to create the VM |                         |
 | AWS_VPC_ID        | false    | The vpc id to use.                    |                         |

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -11,6 +11,7 @@ optionGroups:
       - AWS_PROFILE
       - AWS_AMI
       - AWS_DISK_SIZE
+      - AWS_ROOT_DEVICE
       - AWS_INSTANCE_TYPE
       - AWS_VPC_ID
       - AWS_SUBNET_ID
@@ -64,6 +65,9 @@ options:
   AWS_DISK_SIZE:
     description: The disk size to use.
     default: "40"
+  AWS_ROOT_DEVICE:
+    description: The root device of the disk image.
+    default: ""
   AWS_VPC_ID:
     description: The vpc id to use.
     default: ""

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -237,6 +237,11 @@ func GetAMIRootDevice(ctx context.Context, cfg aws.Config, diskImage string) (st
 		return "", err
 	}
 
+	// Struct spec: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#Image
+	if len(result.Images) == 0 || *result.Images[0].RootDeviceName == "" {
+		return "/dev/sda1", nil
+	}
+
 	return *result.Images[0].RootDeviceName, nil
 }
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -41,6 +41,14 @@ func NewProvider(ctx context.Context, logs log.Logger) (*AwsProvider, error) {
 		config.DiskImage = image
 	}
 
+	if config.RootDevice == "" {
+		device, err := GetAMIRootDevice(ctx, cfg, config.DiskImage)
+		if err != nil {
+			return nil, err
+		}
+		config.RootDevice = device
+	}
+
 	// create provider
 	provider := &AwsProvider{
 		Config:    config,
@@ -213,6 +221,23 @@ func GetDefaultAMI(ctx context.Context, cfg aws.Config, instanceType string) (st
 	})
 
 	return *result.Images[0].ImageId, nil
+}
+
+func GetAMIRootDevice(ctx context.Context, cfg aws.Config, diskImage string) (string, error) {
+	svc := ec2.NewFromConfig(cfg)
+
+	input := &ec2.DescribeImagesInput{
+		ImageIds: []string{
+			diskImage,
+		},
+	}
+	result, err := svc.DescribeImages(ctx, input)
+
+	if err != nil {
+		return "", err
+	}
+
+	return *result.Images[0].RootDeviceName, nil
 }
 
 func GetDevpodInstanceProfile(ctx context.Context, provider *AwsProvider) (string, error) {
@@ -625,7 +650,7 @@ func Create(
 		SecurityGroupIds: devpodSG,
 		BlockDeviceMappings: []types.BlockDeviceMapping{
 			{
-				DeviceName: aws.String("/dev/sda1"),
+				DeviceName: aws.String(providerAws.Config.RootDevice),
 				Ebs: &types.EbsBlockDevice{
 					VolumeSize: &volSizeI32,
 				},

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -9,6 +9,7 @@ import (
 var (
 	AWS_AMI                  = "AWS_AMI"
 	AWS_DISK_SIZE            = "AWS_DISK_SIZE"
+	AWS_ROOT_DEVICE          = "AWS_ROOT_DEVICE"
 	AWS_INSTANCE_TYPE        = "AWS_INSTANCE_TYPE"
 	AWS_REGION               = "AWS_REGION"
 	AWS_SECURITY_GROUP_ID    = "AWS_SECURITY_GROUP_ID"
@@ -21,6 +22,7 @@ var (
 type Options struct {
 	DiskImage          string
 	DiskSizeGB         int
+	RootDevice         string
 	MachineFolder      string
 	MachineID          string
 	MachineType        string
@@ -53,6 +55,7 @@ func FromEnv(init bool) (*Options, error) {
 	}
 
 	retOptions.DiskImage = os.Getenv(AWS_AMI)
+	retOptions.RootDevice = os.Getenv(AWS_ROOT_DEVICE)
 	retOptions.SecurityGroupID = os.Getenv(AWS_SECURITY_GROUP_ID)
 	retOptions.SubnetID = os.Getenv(AWS_SUBNET_ID)
 	retOptions.VpcID = os.Getenv(AWS_VPC_ID)


### PR DESCRIPTION
If you use AWS_DISK_SIZE, it adds an EBS VolumeMapping to the new size.

Unfortunately, while Ubuntu (which would have been MY preference) uses `/dev/sda1`, Amazon Linux uses `/dev/xda1` and the net result is that you end up with a _second_ volume rather than enlarging the first one.

This code tries to get around that by querying the AMI (after it has been configured) and getting the root device name from the AMI definition.  When you pass it in this way, the image ends up on that disk rather than creating a second volume for the instance.

I tested this on our Amazon Linux (yeah, I know....) image and it works fine, but I haven't written much go in the past year so please let me know if there are any changes you would like to see!