### PR TITLE
fix(security): make stricter rules for AWS instance profile

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -232,7 +232,6 @@ func GetAMIRootDevice(ctx context.Context, cfg aws.Config, diskImage string) (st
 		},
 	}
 	result, err := svc.DescribeImages(ctx, input)
-
 	if err != nil {
 		return "", err
 	}
@@ -295,10 +294,7 @@ func CreateDevpodInstanceProfile(ctx context.Context, provider *AwsProvider) (st
             "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": [
-                "ec2:DescribeInstances",
                 "ec2:StopInstances",
-                "ec2:DescribeInstanceStatus",
-				"ec2:DescribeInstanceConnectEndpoints"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
We don't need all those permissions
Harden permissions to improve security

Resolves POD-604