### PR TITLE
feat: Add Spot Instance support

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -54,9 +54,9 @@ func (cmd *DeleteCmd) Run(
 	}
 
 	if len(instances.Reservations) > 0 {
-		targetID := instances.Reservations[0].Instances[0].InstanceId
+		instance := instances.Reservations[0].Instances[0]
 
-		err = aws.Delete(ctx, providerAws.AwsConfig, *targetID)
+		err = aws.Delete(ctx, providerAws.AwsConfig, instance)
 		if err != nil {
 			return err
 		}

--- a/hack/provider/provider-dev.yaml
+++ b/hack/provider/provider-dev.yaml
@@ -20,6 +20,7 @@ optionGroups:
       - AWS_INSTANCE_TAGS
       - AWS_USE_INSTANCE_CONNECT_ENDPOINT
       - AWS_INSTANCE_CONNECT_ENDPOINT_ID
+      - AWS_USE_SPOT_INSTANCE
     name: "AWS options"
     defaultVisible: false
   - options:
@@ -237,6 +238,10 @@ options:
   AWS_INSTANCE_CONNECT_ENDPOINT_ID:
     description: "Specify which instance connect endpoint to use. Only works with AWS_USE_INSTANCE_CONNECT_ENDPOINT enabled"
     default: ""
+  AWS_USE_SPOT_INSTANCE:
+    description: "Prefer the Spot instead of On-Demand instances."
+    type: boolean
+    default: false
   INACTIVITY_TIMEOUT:
     description: If defined, will automatically stop the VM after the inactivity period.
     default: 10m

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -20,6 +20,7 @@ optionGroups:
       - AWS_INSTANCE_TAGS
       - AWS_USE_INSTANCE_CONNECT_ENDPOINT
       - AWS_INSTANCE_CONNECT_ENDPOINT_ID
+      - AWS_USE_SPOT_INSTANCE
     name: "AWS options"
     defaultVisible: false
   - options:
@@ -237,6 +238,10 @@ options:
   AWS_INSTANCE_CONNECT_ENDPOINT_ID:
     description: "Specify which instance connect endpoint to use. Only works with AWS_USE_INSTANCE_CONNECT_ENDPOINT enabled"
     default: ""
+  AWS_USE_SPOT_INSTANCE:
+    description: "Prefer the Spot instead of On-Demand instances."
+    type: boolean
+    default: false
   INACTIVITY_TIMEOUT:
     description: If defined, will automatically stop the VM after the inactivity period.
     default: 10m

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -678,6 +678,15 @@ func Create(
 		TagSpecifications: GetInstanceTags(providerAws),
 		UserData:          &userData,
 	}
+	if providerAws.Config.UseSpotInstance {
+		instance.InstanceMarketOptions = &types.InstanceMarketOptionsRequest{
+			MarketType: "spot",
+			SpotOptions: &types.SpotMarketOptions{
+				SpotInstanceType:             "persistent",
+				InstanceInterruptionBehavior: "stop",
+			},
+		}
+	}
 
 	profile, err := GetDevpodInstanceProfile(ctx, providerAws)
 	if err == nil {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -778,18 +778,29 @@ func Status(ctx context.Context, cfg aws.Config, name string) (client.Status, er
 	}
 }
 
-func Delete(ctx context.Context, cfg aws.Config, instanceID string) error {
+func Delete(ctx context.Context, cfg aws.Config, instance types.Instance) error {
 	svc := ec2.NewFromConfig(cfg)
 
 	input := &ec2.TerminateInstancesInput{
 		InstanceIds: []string{
-			instanceID,
+			*instance.InstanceId,
 		},
 	}
 
 	_, err := svc.TerminateInstances(ctx, input)
 	if err != nil {
 		return err
+	}
+
+	if instance.SpotInstanceRequestId != nil {
+		_, err = svc.CancelSpotInstanceRequests(ctx, &ec2.CancelSpotInstanceRequestsInput{
+			SpotInstanceRequestIds: []string{
+				*instance.SpotInstanceRequestId,
+			},
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -19,6 +19,7 @@ var (
 	AWS_INSTANCE_PROFILE_ARN          = "AWS_INSTANCE_PROFILE_ARN"
 	AWS_USE_INSTANCE_CONNECT_ENDPOINT = "AWS_USE_INSTANCE_CONNECT_ENDPOINT"
 	AWS_INSTANCE_CONNECT_ENDPOINT_ID  = "AWS_INSTANCE_CONNECT_ENDPOINT_ID"
+	AWS_USE_SPOT_INSTANCE             = "AWS_USE_SPOT_INSTANCE"
 )
 
 type Options struct {
@@ -36,6 +37,7 @@ type Options struct {
 	Zone                       string
 	UseInstanceConnectEndpoint bool
 	InstanceConnectEndpointID  string
+	UseSpotInstance            bool
 }
 
 func FromEnv(init bool) (*Options, error) {
@@ -68,6 +70,7 @@ func FromEnv(init bool) (*Options, error) {
 	retOptions.Zone = os.Getenv(AWS_REGION)
 	retOptions.UseInstanceConnectEndpoint = os.Getenv(AWS_USE_INSTANCE_CONNECT_ENDPOINT) == "true"
 	retOptions.InstanceConnectEndpointID = os.Getenv(AWS_INSTANCE_CONNECT_ENDPOINT_ID)
+	retOptions.UseSpotInstance = os.Getenv(AWS_USE_SPOT_INSTANCE) == "true"
 
 	// Return eraly if we're just doing init
 	if init {


### PR DESCRIPTION
## Description

This PR introduces a new option, `AWS_USE_SPOT_INSTANCE`, which creates an EC2 Spot instance with `InstanceMarketOptions` and destroy the Spot request when deleting the instance.

**Why don't I use Fleet?** Fleet does not allow the stop and start of an instance, which is not suitable for our cases. Instead, I start a persistent request of a single Spot machine.

Additionally, I found that "Spot Instances" can reduce the workspace cost by more than 80%.

![CleanShot 2024-06-07 at 01 45 32@2x](https://github.com/loft-sh/devpod-provider-aws/assets/28441561/124eff8c-1546-455b-9a46-c02a595ea980)

Resolved #12 

## Usage

Create a custom provider with the URL: `https://github.com/pan93412/devpod-provider-aws/releases/download/0.3.0/provider.yaml`

## Tests

> [!NOTE]
> It took some time to allow the user to restart the Spot instance, as we needed to wait for the Spot Request to be disabled completely.

- [x] Spot instance should be able to run
- [x] Spot instance should be able to stop and start
- [x] Spot instance should be able to destroy (including their request)
- [x] On-Demand instance should be able to run
- [x] On-Demand should be able to stop and start
- [x] On-Demand instance should be able to destroy
- [x] Spot instances should shutdown automatically after the inactive interval
- [x] Spot instance and their request should be destroy when deleting the workspace even when the workspace is stopped
- [x] Spot instance and their request should be destroy when deleting the workspace even when the workspace is failed
- [x] Continue testing