### PR TITLE
feat: Specify subnet id list and allow selection of availability zone

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -25,6 +25,7 @@ optionGroups:
       - AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER
       - AWS_USE_ROUTE53
       - AWS_ROUTE53_ZONE_NAME
+      - AWS_AVAILABILITY_ZONE
     name: "AWS options"
     defaultVisible: false
   - options:
@@ -83,10 +84,13 @@ options:
     description: The vpc id to use.
     default: ""
   AWS_SUBNET_ID:
-    description: The subnet id to use.
+    description: The subnet id to use. Can also be multiple once separated by a comma. By default the one with the most available IPs is chosen. Can be overridden by AWS_AVAILABILITY_ZONE.
     default: ""
   AWS_SECURITY_GROUP_ID:
     description: The security group id to use. Multiple can be specified by separating with a comma.
+    default: ""
+  AWS_AVAILABILITY_ZONE:
+    description: The name of the AWS availability zone can be specified to choose a subnet out of the desired zone.
     default: ""
   AWS_AMI:
     description: The disk image to use.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -15,6 +16,7 @@ var (
 	AWS_SECURITY_GROUP_ID               = "AWS_SECURITY_GROUP_ID"
 	AWS_SUBNET_ID                       = "AWS_SUBNET_ID"
 	AWS_VPC_ID                          = "AWS_VPC_ID"
+	AWS_AVAILABILITY_ZONE               = "AWS_AVAILABILITY_ZONE"
 	AWS_INSTANCE_TAGS                   = "AWS_INSTANCE_TAGS"
 	AWS_INSTANCE_PROFILE_ARN            = "AWS_INSTANCE_PROFILE_ARN"
 	AWS_USE_INSTANCE_CONNECT_ENDPOINT   = "AWS_USE_INSTANCE_CONNECT_ENDPOINT"
@@ -35,7 +37,8 @@ type Options struct {
 	MachineID                  string
 	MachineType                string
 	VpcID                      string
-	SubnetID                   string
+	SubnetIDs                  []string
+	AvailabilityZone           string
 	SecurityGroupID            string
 	InstanceProfileArn         string
 	InstanceTags               string
@@ -74,8 +77,8 @@ func FromEnv(init bool) (*Options, error) {
 	retOptions.DiskImage = os.Getenv(AWS_AMI)
 	retOptions.RootDevice = os.Getenv(AWS_ROOT_DEVICE)
 	retOptions.SecurityGroupID = os.Getenv(AWS_SECURITY_GROUP_ID)
-	retOptions.SubnetID = os.Getenv(AWS_SUBNET_ID)
 	retOptions.VpcID = os.Getenv(AWS_VPC_ID)
+	retOptions.AvailabilityZone = os.Getenv(AWS_AVAILABILITY_ZONE)
 	retOptions.InstanceTags = os.Getenv(AWS_INSTANCE_TAGS)
 	retOptions.InstanceProfileArn = os.Getenv(AWS_INSTANCE_PROFILE_ARN)
 	retOptions.Zone = os.Getenv(AWS_REGION)
@@ -86,6 +89,13 @@ func FromEnv(init bool) (*Options, error) {
 	retOptions.KmsKeyARNForSessionManager = os.Getenv(AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER)
 	retOptions.UseRoute53Hostnames = os.Getenv(AWS_USE_ROUTE53) == "true"
 	retOptions.Route53ZoneName = os.Getenv(AWS_ROUTE53_ZONE_NAME)
+
+	subnetIDs := os.Getenv(AWS_SUBNET_ID)
+	if subnetIDs != "" {
+		for _, subnetID := range strings.Split(os.Getenv(AWS_SUBNET_ID), ",") {
+			retOptions.SubnetIDs = append(retOptions.SubnetIDs, strings.TrimSpace(subnetID))
+		}
+	}
 
 	// Return early if we're just doing init
 	if init {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -92,7 +92,7 @@ func FromEnv(init bool) (*Options, error) {
 
 	subnetIDs := os.Getenv(AWS_SUBNET_ID)
 	if subnetIDs != "" {
-		for _, subnetID := range strings.Split(os.Getenv(AWS_SUBNET_ID), ",") {
+		for _, subnetID := range strings.Split(subnetIDs, ",") {
 			retOptions.SubnetIDs = append(retOptions.SubnetIDs, strings.TrimSpace(subnetID))
 		}
 	}


### PR DESCRIPTION
This PR:

- refactors the determination of the machine's subnet ID by moving all related code to the `GetSubnet()` function instead of having it partly in `Create()` and `GetSubnetID()`.
- allows the user to specify more than a single subnet id. If more than one is specified, the least occupied subnet is choosen.
- allows the determination of subnets based on `devpod:devpod` tag without providing a VPC ID. I think this was a bug. The code required to have a VPC ID specified in this case, however it didn't do anything with the value in this decision branch.
- allows the user to specify an availability zone. Subnets are than filtered by this zone. This feature is for example meant to provide a workaround to get a workspace up and running even during a zone outage on AWS side. 

<sub>Jan Roehrich <jan.roehrich@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub> 