### PR TITLE
Issue #46 Fix - Updating the default image logic

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -250,7 +250,7 @@ func GetDefaultAMI(ctx context.Context, cfg aws.Config, instanceType string) (st
 
 	imageName := "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-%s-*"
 
-	architecture := "x86_64"
+	architecture := "amd64"
 	// Graviton instances terminate with g
 	if strings.HasSuffix(strings.Split(instanceType, ".")[0], "g") {
 		architecture = "arm64"


### PR DESCRIPTION
Addresses https://github.com/loft-sh/devpod-provider-aws/issues/46

The description conventions used in AWS for Ubuntu have changed and the 22.04 LTS image can no longer be located. This new logic uses the AMI name string as it is a more stable mechanism

The hard-coding of 22.04 may need to be revisited in the future.