### PR TITLE
Fix array index out of range error in GetDefaultAMI

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -298,6 +298,11 @@ func GetDefaultAMI(ctx context.Context, cfg aws.Config, instanceType string) (st
 		return "", err
 	}
 
+	// Check if any images were found
+	if len(result.Images) == 0 {
+		return "", fmt.Errorf("no matching AMI found for architecture %s with Ubuntu 22.04 LTS - you may need to specify a custom AMI using the AWS_AMI option", architecture)
+	}
+
 	// Sort by date, so we take the latest AMI available for Ubuntu 22.04
 	sort.Slice(result.Images, func(i, j int) bool {
 		iTime, err := time.Parse("2006-01-02T15:04:05.000Z", *result.Images[i].CreationDate)


### PR DESCRIPTION
This resolves [the 'index out of range [0] with length 0' error during provider initialization issue](https://github.com/loft-sh/devpod-provider-aws/issues/46) by doing the following during provider init:

This preserves existing functionallity/backwards compatibility while addressing the out of bounds error.

- Add bounds checking before accessing result.Images[0]
- Return informative error when no matching Ubuntu 22.04 AMIs found
- Fixes panic when provider tries to auto-discover AMI in accounts without public Ubuntu AMIs